### PR TITLE
Serialize JSON payloads as str

### DIFF
--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -59,13 +59,14 @@ paths:
                     type: array
                     items:
                       type: object
-                      required: [validating_pubkey, derivation_path]
+                      required: [validating_pubkey]
                       properties:
                         validating_pubkey:
                           $ref: "#/components/schemas/Pubkey"
                         derivation_path:
                           type: string
                           description: The derivation path (if present in the imported keystore).
+                          example: "m/12381/3600/0/0/0"
                         readonly:
                           type: boolean
                           description: The key associated with this pubkey cannot be deleted from the API
@@ -99,15 +100,15 @@ paths:
                   type: array
                   description: JSON-encoded keystore files generated with the Launchpad.
                   items:
-                    type: object
+                    $ref: "#/components/schemas/Keystore"
                 passwords:
                   type: array
                   description: Passwords to unlock imported keystore files. `passwords[i]` must unlock `keystores[i]`.
                   items:
                     type: string
+                    example: "ABCDEFGH01234567ABCDEFGH01234567"
                 slashing_protection:
-                  type: object
-                  description: Slashing protection of the imported keys data in EIP-3076 JSON format.
+                  $ref: "#/components/schemas/SlashingProtectionData"
       responses:
         "200":
           description: Success response
@@ -135,6 +136,7 @@ paths:
                             - imported
                             - duplicate
                             - error
+                          example: imported
                         message:
                           type: string
                           description: error message if status == error
@@ -205,14 +207,12 @@ paths:
                             - not_active
                             - not_found
                             - error
+                          example: deleted
                         message:
                           type: string
                           description: error message if status == error
                   slashing_protection:
-                    type: object
-                    description: |
-                      JSON representation of the slash protection data in format defined in EIP-3076: Slashing
-                      Protection Interchange Format.
+                    $ref: "#/components/schemas/SlashingProtectionData"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -231,8 +231,21 @@ components:
     Pubkey:
       type: string
       pattern: "^0x[a-fA-F0-9]{96}$"
-      description: "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._"
+      description: |
+        The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._
       example: "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+
+    Keystore:
+      type: string
+      description: |
+        JSON serialized representation of a single keystore in EIP-2335: BLS12-381 Keystore format.
+      example: '{"version":4,"uuid":"9f75a3fa-1e5a-49f9-be3d-f5a19779c6fa","path":"m/12381/3600/0/0/0","pubkey":"0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a","crypto":{"kdf":{"function":"pbkdf2","params":{"dklen":32,"c":262144,"prf":"hmac-sha256","salt":"8ff8f22ef522a40f99c6ce07fdcfc1db489d54dfbc6ec35613edf5d836fa1407"},"message":""},"checksum":{"function":"sha256","params":{},"message":"9678a69833d2576e3461dd5fa80f6ac73935ae30d69d07659a709b3cd3eddbe3"},"cipher":{"function":"aes-128-ctr","params":{"iv":"31b69f0ac97261e44141b26aa0da693f"},"message":"e8228bafec4fcbaca3b827e586daad381d53339155b034e5eaae676b715ab05e"}}}'
+
+    SlashingProtectionData:
+      type: string
+      description: |
+        JSON serialized representation of the slash protection data in format defined in EIP-3076: Slashing Protection Interchange Format.
+      example: '{"metadata":{"interchange_format_version":"5","genesis_validators_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"},"data":[{"pubkey":"0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a","signed_blocks":[],"signed_attestations":[]}]}'
 
     ErrorResponse:
       type: object
@@ -241,6 +254,7 @@ components:
         message:
           description: "Message describing error"
           type: string
+          example: "Internal server error"
 
   responses:
     Unauthorized:


### PR DESCRIPTION
As discussed internally:
- Declaring as string prevents having to declare the format in openapi
- Allows consumers to skip serialization and serialization if desired 