### PR TITLE
Update license and clean up docs/references

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Bundle json spec
         uses: mpetrunic/swagger-cli-action@v1.0.0
         with:
-          command: "bundle ./keymanager-oapi.yaml -r -t json -o ./deploy/beacon-node-oapi.json"
+          command: "bundle ./keymanager-oapi.yaml -r -t json -o ./deploy/keymanager-oapi.json"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -43,8 +43,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./deploy/beacon-node-oapi.json
-          asset_name: beacon-node-oapi.json
+          asset_path: ./deploy/keymanager-oapi.json
+          asset_name: keymanager-oapi.json
           asset_content_type: application/json
       - name: Rollback Release
         if: failure()

--- a/README.md
+++ b/README.md
@@ -25,16 +25,17 @@ such as GUIs, alerts, etc.
 
 ## Render
 
-To render spec in browser you will need any http server to load `index.html` file
-in root of the repo.
+To render the spec in a browser you will need an HTTP server to serve the `index.html` file.
+Rendering occurs client-side in JavaScript, so no changes are required to the HTML file between
+edits.
 
 ##### Python
 
 ```
-python -m SimpleHTTPServer 8080
+python2 -m SimpleHTTPServer 8080
 ```
 
-And api spec will render on [http://localhost:8080](http://localhost:8080).
+The API spec will render on [http://localhost:8080](http://localhost:8080).
 
 ##### NodeJs
 
@@ -48,13 +49,13 @@ yarn global add simplehttpserver
 simplehttpserver
 ```
 
-And api spec will render on [http://localhost:8000](http://localhost:8000).
+The API spec will render on [http://localhost:8000](http://localhost:8000).
 
 ## Contributing
 
-Api spec is checked for lint errors before merge.
+The API spec is linted for issues before PRs are merged.
 
-To run lint locally, install linter with
+To run the linter locally, install `spectral`:
 
 ```
 npm install -g @stoplight/spectral
@@ -64,30 +65,24 @@ npm install -g @stoplight/spectral
 yarn global add @stoplight/spectral
 ```
 
-and run lint with
+and run with
 
 ```
-spectral lint beacon-node-oapi.yaml
+spectral lint keymanager-oapi.yaml
 ```
-
-## Implementations
-
-- [TypeScript Wrapper](https://www.npmjs.com/package/@chainsafe/eth2.0-api-wrapper)
-
-https://www.npmjs.com/package/@chainsafe/eth2.0-api-wrapper
 
 ## Releasing
 
-1. Create and push tag
+1. Create and push a tag
 
-   - Make sure info.version in beacon-node-oapi.yaml file is updated before tagging.
+   - Make sure info.version in keymanager-oapi.yaml file is updated before tagging.
    - CD will create github release and upload bundled spec file
 
 2. Add release entrypoint in index.html
 
 In SwaggerUIBundle configuration (inside index.html file), add another entry in "urls" field (SwaggerUI will load first item as default).
-Entry should be in following format(replace `<tag>` with real tag name from step 1.):
+Entries should be in the following format (replace `<tag>` with the real tag name from step 1):
 
 ```javascript
-         {url: "https://github.com/ethereum/keymanager-APIs/releases/download/<tag>/beacon-node-oapi.yaml", name: "<tag>"},
+         {url: "https://github.com/ethereum/keymanager-APIs/releases/download/<tag>/keymanager-oapi.yaml", name: "<tag>"},
 ```

--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -15,13 +15,13 @@ info:
     All sensitive routes are to be authenticated with a token. This token should be provided by the user via a secure channel:
       - Log the token to stdout when running the binary with the key manager API enabled
       - Read the token from a file available to the binary
-  version: "Dev - Eth2Spec v1.0.1"
+  version: "v1.0.0-alpha"
   contact:
     name: Ethereum Github
-    url: https://github.com/ethereum/eth2.0-apis/issues
+    url: https://github.com/ethereum/keymanager-APIs/issues
   license:
-    name: "Apache 2.0"
-    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+    name: "Creative Commons Zero v1.0 Universal"
+    url: "https://creativecommons.org/publicdomain/zero/1.0/"
 
 servers:
   - url: "{server_url}"


### PR DESCRIPTION
Updated the license in the YAML to CC and renamed a few missed `beacon-node` references to `keymanager`