### PR TITLE
Add HTTP 400 responses for POST and DELETE

### DIFF
--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -140,6 +140,8 @@ paths:
                         message:
                           type: string
                           description: error message if status == error
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -213,6 +215,8 @@ paths:
                           description: error message if status == error
                   slashing_protection:
                     $ref: "#/components/schemas/SlashingProtectionData"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -252,11 +256,18 @@ components:
       required: [message]
       properties:
         message:
-          description: "Message describing error"
+          description: "Detailed error message"
           type: string
-          example: "Internal server error"
+          example: "description of the error that occurred"
 
   responses:
+    BadRequest:
+      description: "Bad request. Request was malformed and could not be processed"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
     Unauthorized:
       description: "Unauthorized, no token is found"
       content:
@@ -272,7 +283,8 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
 
     InternalError:
-      description: "Beacon node internal error."
+      description: "Internal server error. The server encountered an unexpected error indicative of
+                    a serious fault in the system, or a bug."
       content:
         application/json:
           schema:


### PR DESCRIPTION
Specify the structure of the "bad request" response with status code 400.

The details for when these errors are to be returned will be fleshed out in subsequent PRs. In general the API should prefer to return error statuses for individual keys, but in some cases that isn't possible, e.g.

- Malformed JSON input
- Mismatched numbers of keystores and passwords for POST
- Malformed slashing protection data for POST

See also https://github.com/ethereum/keymanager-APIs/tree/master/flows#process-flows and https://github.com/ethereum/keymanager-APIs/pull/10