### PR TITLE
Add remote keys routes

### DIFF
--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -286,8 +286,9 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
 
     InternalError:
-      description: "Internal server error. The server encountered an unexpected error indicative of
-                    a serious fault in the system, or a bug."
+      description: |
+        Internal server error. The server encountered an unexpected error indicative of
+        a serious fault in the system, or a bug.
       content:
         application/json:
           schema:

--- a/validator-client-oapi.yml
+++ b/validator-client-oapi.yml
@@ -193,7 +193,7 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
+      bearerFormat: URL safe token, optionally JWT
 
   schemas:
     Pubkey:

--- a/validator-client-oapi.yml
+++ b/validator-client-oapi.yml
@@ -131,8 +131,7 @@ paths:
         DELETE must delete all keys from `request.pubkeys` that are known to the validator client and exist in its
         persistent storage. 
 
-        DELETE should never return a 404 response, even if all pubkeys from request.pubkeys have no extant keystores
-        nor slashing protection data.
+        DELETE should never return a 404 response, even if all pubkeys from request.pubkeys have no existing keystores.
       security:
         - bearerAuth: []
       tags:

--- a/validator-client-oapi.yml
+++ b/validator-client-oapi.yml
@@ -35,7 +35,7 @@ tags:
     description: Set of endpoints for key management.
 
 paths:
-  /eth/v1/remotekey:
+  /eth/v1/remotekeys:
     get:
       operationId: ListRemoteKeys
       summary: List Remote Keys.
@@ -214,6 +214,9 @@ components:
           description: "URL to API implementing EIP-3030: BLS Remote Signer HTTP API"
           type: string
           example: "https://remote.signer"
+        readonly:
+          type: boolean
+          description: The signer associated with this pubkey cannot be deleted from the API
 
     ErrorResponse:
       type: object

--- a/validator-client-oapi.yml
+++ b/validator-client-oapi.yml
@@ -242,7 +242,7 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
 
     InternalError:
-      description: "Beacon node internal error."
+      description: "Unexpected internal error."
       content:
         application/json:
           schema:

--- a/validator-client-oapi.yml
+++ b/validator-client-oapi.yml
@@ -1,0 +1,248 @@
+openapi: "3.0.3"
+
+info:
+  title: "Eth2 validator client API"
+  description: |
+    API specification for a validator client that supports connecting to a remote signer.
+
+    The validator client API is served by the binary performing the validator flow. This binary may be a validator client or a beacon + vc single binary.
+
+    All routes SHOULD be exposed through a secure channel, such as with HTTPs, an SSH tunnel, a VPN, etc.
+
+    All requests by default send and receive JSON, and as such should have either or both of the "Content-Type: application/json"
+    and "Accept: application/json" headers.
+
+    All sensitive routes are to be authenticated with a token. This token should be provided by the user via a secure channel:
+      - Log the token to stdout when running the binary with the validator client enabled
+      - Read the token from a file available to the binary
+  version: "Dev - Eth2Spec v1.0.1"
+  contact:
+    name: Ethereum Github
+    url: https://github.com/ethereum/keymanager-APIs/issues
+  license:
+    name: "Apache 2.0"
+    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+
+servers:
+  - url: "{server_url}"
+    variables:
+      server_url:
+        description: "key manager API url"
+        default: "https://public-mainnet-node.ethereum.org"
+
+tags:
+  - name: RemoteKeymanager
+    description: Set of endpoints for key management.
+
+paths:
+  /eth/v1/remotekey:
+    get:
+      operationId: ListRemoteKeys
+      summary: List Remote Keys.
+      description: |
+        List all remote validating pubkeys known to this validator client binary
+      security:
+        - bearerAuth: []
+      tags:
+        - RemoteKeymanager
+      responses:
+        "200":
+          description: Success response
+          content:
+            application/json:
+              schema:
+                title: ListRemoteKeysResponse
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SignerDefinition"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    post:
+      operationId: ImportRemoteKeys
+      summary: Import Remote Keys.
+      description: |
+        Import remote keys for the validator client to request duties for.
+      security:
+        - bearerAuth: []
+      tags:
+        - RemoteKeymanager
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [keystores, passwords]
+              properties:
+                remote_keys:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/SignerDefinition"
+      responses:
+        "200":
+          description: Success response
+          content:
+            application/json:
+              schema:
+                title: ImportRemoteKeysResponse
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: array
+                    description: Status result of each `request.remote_keys` with same length and order of `request.remote_keys`
+                    items:
+                      type: object
+                      required: [status]
+                      properties:
+                        status:
+                          type: string
+                          description: |
+                            - imported: Remote key successfully imported to validator client permanent storage
+                            - duplicate: Remote key's pubkey is already known to the validator client
+                            - error: Any other status different to the above: I/O errors, etc.
+                          enum:
+                            - imported
+                            - duplicate
+                            - error
+                          example: imported
+                        message:
+                          type: string
+                          description: error message if status == error
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: DeleteRemoteKeys
+      summary: Delete Remote Keys.
+      description: |
+        DELETE must delete all keys from `request.pubkeys` that are known to the validator client and exist in its
+        persistent storage. 
+
+        DELETE should never return a 404 response, even if all pubkeys from request.pubkeys have no extant keystores
+        nor slashing protection data.
+      security:
+        - bearerAuth: []
+      tags:
+        - RemoteKeymanager
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [pubkeys]
+              properties:
+                pubkeys:
+                  type: array
+                  description: List of public keys to delete.
+                  items:
+                    $ref: "#/components/schemas/Pubkey"
+      responses:
+        "200":
+          description: Success response
+          content:
+            application/json:
+              schema:
+                title: DeleteRemoteKeysResponse
+                type: object
+                required: [data, slashing_protection]
+                properties:
+                  data:
+                    type: array
+                    description: Deletion status of all keys in `request.pubkeys` in the same order.
+                    items:
+                      type: object
+                      required: [status]
+                      properties:
+                        status:
+                          type: string
+                          description: |
+                            - deleted: key was active and removed
+                            - not_active: key is known but was already not active
+                            - not_found: key was not found to be removed
+                            - error: unexpected condition meant the key could not be removed (the key was actually found,
+                              but we couldn't stop using it) - this would be a sign that making it active elsewhere would
+                              almost certainly cause you headaches / slashing conditions etc.
+                          enum:
+                            - deleted
+                            - not_active
+                            - not_found
+                            - error
+                          example: deleted
+                        message:
+                          type: string
+                          description: error message if status == error
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Pubkey:
+      type: string
+      pattern: "^0x[a-fA-F0-9]{96}$"
+      description: |
+        The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._
+      example: "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+
+    SignerDefinition:
+      type: object
+      required: [pubkey, url]
+      properties:
+        pubkey:
+          $ref: "#/components/schemas/Pubkey"
+        url:
+          type: string
+          example: "https://remote.signer"
+
+    ErrorResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          description: "Message describing error"
+          type: string
+          example: "Internal server error"
+
+  responses:
+    Unauthorized:
+      description: "Unauthorized, no token is found"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    Forbidden:
+      description: "Forbidden, a token is found but is invalid"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    InternalError:
+      description: "Beacon node internal error."
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"

--- a/validator-client-oapi.yml
+++ b/validator-client-oapi.yml
@@ -80,7 +80,7 @@ paths:
           application/json:
             schema:
               type: object
-              required: [keystores, passwords]
+              required: [remote_keys]
               properties:
                 remote_keys:
                   type: array
@@ -157,7 +157,7 @@ paths:
               schema:
                 title: DeleteRemoteKeysResponse
                 type: object
-                required: [data, slashing_protection]
+                required: [data]
                 properties:
                   data:
                     type: array
@@ -170,14 +170,12 @@ paths:
                           type: string
                           description: |
                             - deleted: key was active and removed
-                            - not_active: key is known but was already not active
                             - not_found: key was not found to be removed
                             - error: unexpected condition meant the key could not be removed (the key was actually found,
                               but we couldn't stop using it) - this would be a sign that making it active elsewhere would
                               almost certainly cause you headaches / slashing conditions etc.
                           enum:
                             - deleted
-                            - not_active
                             - not_found
                             - error
                           example: deleted
@@ -213,6 +211,7 @@ components:
         pubkey:
           $ref: "#/components/schemas/Pubkey"
         url:
+          description: "URL to API implementing EIP-3030: BLS Remote Signer HTTP API"
           type: string
           example: "https://remote.signer"
 

--- a/validator-client-oapi.yml
+++ b/validator-client-oapi.yml
@@ -206,7 +206,7 @@ components:
 
     SignerDefinition:
       type: object
-      required: [pubkey, url]
+      required: [pubkey]
       properties:
         pubkey:
           $ref: "#/components/schemas/Pubkey"


### PR DESCRIPTION
Validator clients support using a remote signer for signing. However, implementations require keys to be explicitly declared via some config file or via a reload signal to the binary.

This routes expose such functionality through an authenticated API very similar to https://github.com/ethereum/keymanager-APIs/blob/master/keymanager-oapi.yaml

**Rationale**

TBD

**Process flows**

TBD