### PR TITLE
fee-recipient: request body string to json object

### DIFF
--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -63,9 +63,9 @@ post:
         schema:
             title: SetFeeRecipientRequest
             type: object
-            required: [fee_recipient]
+            required: [ethaddress]
             properties:
-              fee_recipient:
+              ethaddress:
                 $ref: '../keymanager-oapi.yaml#/components/schemas/EthAddress'
   responses:
     "202":

--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -63,9 +63,9 @@ post:
         schema:
             title: SetFeeRecipientRequest
             type: object
-            required: [address]
+            required: [fee_recipient]
             properties:
-              address:
+              fee_recipient:
                 $ref: '../keymanager-oapi.yaml#/components/schemas/EthAddress'
   responses:
     "202":

--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -61,8 +61,12 @@ post:
     content:
       application/json:
         schema:
-          $ref: '../keymanager-oapi.yaml#/components/schemas/EthAddress'
-          required: true
+            title: SetFeeRecipientRequest
+            type: object
+            required: [address]
+            properties:
+              address:
+                $ref: '../keymanager-oapi.yaml#/components/schemas/EthAddress'
   responses:
     "202":
       description: successfully updated


### PR DESCRIPTION
I'd like to propose a spec update to the set fee recipient API changing it from a string to a json object. This will clarify the request property being sent and simply some client limitations. Prysm uses an API middleware that translates to a gRPC gateway. this will greatly reduce implementation time and also clarify the request body.