### PR TITLE
remove pubkey from the GET response

### DIFF
--- a/types/fee_recipient.yaml
+++ b/types/fee_recipient.yaml
@@ -1,7 +1,5 @@
 type: object
-required: [pubkey,ethaddress]
+required: [ethaddress]
 properties:
-  pubkey:
-    $ref: './public_key.yaml'
   ethaddress:
     $ref: './eth_address.yaml'

--- a/types/fee_recipient.yaml
+++ b/types/fee_recipient.yaml
@@ -1,5 +1,7 @@
 type: object
 required: [ethaddress]
 properties:
+  pubkey:
+    $ref: './public_key.yaml'
   ethaddress:
     $ref: './eth_address.yaml'


### PR DESCRIPTION
Because we're referencing a single validator, there's no value in having the pubkey also in the response, so I suggest we remove it.