### PR TITLE
add delete fee recipient endpoint

### DIFF
--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -80,3 +80,30 @@ post:
       $ref: "../keymanager-oapi.yaml#/components/responses/NotFound"
     "500":
       $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"
+delete:
+  operationId: DeleteFeeRecipient
+  summary: Delete Configured Fee Recipient
+  description: Delete a configured fee recipient mapping for the specified public key.
+  security:
+    - bearerAuth: [ ]
+  tags:
+    - Fee Recipient
+  responses:
+    "204":
+      description: Successfully removed the mapping, or there was no mapping to remove for a key that the server is managing.
+    "401":
+      $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
+    "403":
+      description: A mapping was found, but cannot be removed. This may be because the mapping was in configuration files that cannot be updated.
+      content:
+        application/json:
+          schema:
+            $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
+    "404":
+      description: The key was not found on the server, nothing to delete.
+      content:
+        application/json:
+          schema:
+            $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
+    "500":
+      $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"

--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -88,6 +88,12 @@ delete:
     - bearerAuth: [ ]
   tags:
     - Fee Recipient
+  parameters:
+    - in: path
+      name: pubkey
+      schema:
+        $ref: "../keymanager-oapi.yaml#/components/schemas/Pubkey"
+      required: true
   responses:
     "204":
       description: Successfully removed the mapping, or there was no mapping to remove for a key that the server is managing.


### PR DESCRIPTION
 - removed 400 code, there's really no reason for 400 in this request.
 - added 403, which will allow us to respond appropriately if the key can't be removed.