### PR TITLE
Use HTTP 200s in fee recipient API

### DIFF
--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -68,8 +68,18 @@ post:
               ethaddress:
                 $ref: '../keymanager-oapi.yaml#/components/schemas/EthAddress'
   responses:
-    "202":
-      description: successfully updated
+    "200":
+      description: Successfully updated
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [status]
+            properties:
+              status:
+                type: string
+                enum:
+                  - success
     "400":
       $ref: "../keymanager-oapi.yaml#/components/responses/BadRequest"
     "401":
@@ -95,8 +105,18 @@ delete:
         $ref: "../keymanager-oapi.yaml#/components/schemas/Pubkey"
       required: true
   responses:
-    "204":
+    "200":
       description: Successfully removed the mapping, or there was no mapping to remove for a key that the server is managing.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [status]
+            properties:
+              status:
+                type: string
+                enum:
+                  - success
     "401":
       $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
     "403":


### PR DESCRIPTION
I don't think 202 and 204 are the correct status codes to use for the fee recipient responses. These are status codes with very specific meanings in the HTTP protocol and I think our use of them is unjustified and overcomplicates things.

Regarding 202:

>  The HyperText Transfer Protocol (HTTP) 202 Accepted response status code indicates that the request has been accepted for processing, **but the processing has not been completed**; in fact, processing may not have started yet. The request might or might not eventually be acted upon, as it might be disallowed when processing actually takes place. 

Emphasis added, text from https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202

Sending a 202 "processing not completed" is inaccurate if the fee-recipient POST is actually processed synchronously, which seems like an obvious way to implement it. To _require_ an async response when we don't do this anywhere else in the API is strange.

---

Regarding 204 for delete:

My argument against the 204 isn't as strong, except to say that the decision to send "no content" in response is entirely up to the API, we could just as well send a body with the message too. Sending an extra 21 bytes for `{"status":"success"}` is negligible from a performance and bandwidth PoV.