### PR TITLE
adding 400 error for fee recipient APIs

### DIFF
--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -28,6 +28,8 @@ get:
             properties:
               data:
                 $ref: "../keymanager-oapi.yaml#/components/schemas/FeeRecipient"
+    "400":
+      $ref: "../keymanager-oapi.yaml#/components/responses/BadRequest"
     "401":
       $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
     "403":
@@ -97,6 +99,8 @@ delete:
   responses:
     "204":
       description: Successfully removed the mapping, or there was no mapping to remove for a key that the server is managing.
+    "400":
+      $ref: "../keymanager-oapi.yaml#/components/responses/BadRequest"
     "401":
       $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
     "403":


### PR DESCRIPTION
based on issue #55 it seems like it would be best to respond with a 400 error if it doesn't exist.
prysm now throws this error instead of just defaulting to the burn address.