### PR TITLE
Update tag description to be more explicit about validator client only endpoints

### DIFF
--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -32,9 +32,9 @@ servers:
 
 tags:
   - name: Fee Recipient
-    description: Set of endpoints for management of fee recipient.
+    description: Set of endpoints for management of fee recipient. Available on validator clients only and requires access to a beacon node.
   - name: Gas Limit
-    description: Set of endpoints for management of gas limits.
+    description: Set of endpoints for management of gas limits. Available on validator clients only and requires access to a beacon node.
   - name: Local Key Manager
     description: Set of endpoints for key management of local keys.
   - name: Remote Key Manager


### PR DESCRIPTION
The API spec doesn't currently define what is intended for validator clients, and what is intended for signers.

Michael mentioned that this is documented in the README:
https://github.com/ethereum/keymanager-APIs#v1-apis

It would be nice to make it clearer on the API spec page. With OAPI, I don't think we can group the tags further so I've added some text to the tag description. Other ideas welcome!