### PR TITLE
fix: update uint64 regex to allow 0 as value

### DIFF
--- a/types/uint.yaml
+++ b/types/uint.yaml
@@ -1,4 +1,4 @@
 Uint64:
   type: string
-  pattern: ^[1-9][0-9]{0,19}$
+  pattern: ^(0|[1-9][0-9]{0,19})$
   example: "30000000"


### PR DESCRIPTION
Current uint64 regex does not allow 0 as value but since this is used by epoch and validator index, it must be supported.