### PR TITLE
Add graffiti API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ such as GUIs, alerts, etc.
 Learn about the Consensus Validator Clients that implement these APIs on the [Ethereum.org](https://ethereum.org/)
 
 ### v1 APIS
-| Validator Client/Remote Managers | local keymanager | remote keymanager | fee recipient | gas limit  |
-| -------------------------------- | ---------------- | ----------------- | ------------- |------------|
-| Prysm                            | production       | production        | production    | production |
-| Teku                             | production       | production        | production    | production |
-| Lighthouse                       | v2.1.2           | v2.3.0            | v2.4.0        | v3.0.0     |
-| Nimbus                           | production       | production        | 22.7.0        | -          |
-| Lodestar                         | production       | v0.40.0           | production    | production |
-| Web3signer                       | production       | N/A               | N/A           | N/A        |
+
+| Validator Client/Remote Managers | local keymanager | remote keymanager | fee recipient | gas limit  | graffiti |
+| -------------------------------- | ---------------- | ----------------- | ------------- | ---------- | -------- |
+| Prysm                            | production       | production        | production    | production | -        |
+| Teku                             | production       | production        | production    | production | -        |
+| Lighthouse                       | v2.1.2           | v2.3.0            | v2.4.0        | v3.0.0     | -        |
+| Nimbus                           | production       | production        | 22.7.0        | -          | -        |
+| Lodestar                         | production       | v0.40.0           | production    | production | v1.12.0  |
+| Web3signer                       | production       | N/A               | N/A           | N/A        | N/A      |
 
 ## Use Cases
 
@@ -50,7 +51,7 @@ Further detail on expected behavior and error states of the APIs are listed in t
 
 To render the spec in a browser you will need an HTTP server to serve the `index.html` file.
 Rendering occurs client-side in JavaScript, so no changes are required to the HTML file between
-edits.   
+edits.
 
 ##### Python
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Learn about the Consensus Validator Clients that implement these APIs on the [Et
 | Teku                             | production       | production        | production    | production | -        |
 | Lighthouse                       | v2.1.2           | v2.3.0            | v2.4.0        | v3.0.0     | -        |
 | Nimbus                           | production       | production        | 22.7.0        | -          | -        |
-| Lodestar                         | production       | v0.40.0           | production    | production | v1.12.0  |
+| Lodestar                         | v0.35.0          | v0.40.0           | v1.2.0        | v1.2.0     | v1.12.0  |
 | Web3signer                       | production       | N/A               | N/A           | N/A        | N/A      |
 
 ## Use Cases

--- a/apis/graffiti.yaml
+++ b/apis/graffiti.yaml
@@ -1,0 +1,122 @@
+get:
+  operationId: getGraffiti
+  summary: Get Graffiti
+  description: |
+    Get the graffiti for an individual validator. This graffiti is the one used by the
+    validator when proposing blocks. If no graffiti has been set explicitly for
+    a key then the process-wide default will be returned.
+  security:
+    - bearerAuth: []
+  tags:
+    - Graffiti
+  parameters:
+    - in: path
+      name: pubkey
+      schema:
+        $ref: "../keymanager-oapi.yaml#/components/schemas/Pubkey"
+      required: true
+  responses:
+    "200":
+      description: success response
+      content:
+        application/json:
+          schema:
+            title: ListGraffitiResponse
+            type: object
+            required: [data]
+            properties:
+              data:
+                type: object
+                required: [graffiti]
+                properties:
+                  pubkey:
+                    $ref: "../keymanager-oapi.yaml#/components/schemas/Pubkey"
+                  graffiti:
+                    $ref: "../keymanager-oapi.yaml#/components/schemas/Graffiti"
+    "400":
+      $ref: "../keymanager-oapi.yaml#/components/responses/BadRequest"
+    "401":
+      $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
+    "403":
+      $ref: "../keymanager-oapi.yaml#/components/responses/Forbidden"
+    "404":
+      $ref: "../keymanager-oapi.yaml#/components/responses/NotFound"
+    "500":
+      $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"
+
+post:
+  operationId: setGraffiti
+  summary: Set Graffiti
+  description: |
+    Set the graffiti for an individual validator. This graffiti will be used instead
+    of the process-wide default by the validator when proposing blocks.
+  security:
+    - bearerAuth: []
+  tags:
+    - Graffiti
+  parameters:
+    - in: path
+      name: pubkey
+      schema:
+        $ref: "../keymanager-oapi.yaml#/components/schemas/Pubkey"
+      required: true
+  requestBody:
+    content:
+      application/json:
+        schema:
+          title: SetGraffitiRequest
+          type: object
+          required: [graffiti]
+          properties:
+            graffiti:
+              $ref: "../keymanager-oapi.yaml#/components/schemas/Graffiti"
+  responses:
+    "202":
+      description: successfully updated
+    "400":
+      $ref: "../keymanager-oapi.yaml#/components/responses/BadRequest"
+    "401":
+      $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
+    "403":
+      $ref: "../keymanager-oapi.yaml#/components/responses/Forbidden"
+    "404":
+      $ref: "../keymanager-oapi.yaml#/components/responses/NotFound"
+    "500":
+      $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"
+
+delete:
+  operationId: deleteGraffiti
+  summary: Delete Configured Graffiti
+  description: |
+    Delete the configured graffiti for the specified public key.
+  security:
+    - bearerAuth: []
+  tags:
+    - Graffiti
+  parameters:
+    - in: path
+      name: pubkey
+      schema:
+        $ref: "../keymanager-oapi.yaml#/components/schemas/Pubkey"
+      required: true
+  responses:
+    "204":
+      description: Successfully removed the graffiti, or there was no graffiti set for the requested public key.
+    "400":
+      $ref: "../keymanager-oapi.yaml#/components/responses/BadRequest"
+    "401":
+      $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
+    "403":
+      description: A graffiti was found, but cannot be removed. This may be because the graffit was in configuration files that cannot be updated.
+      content:
+        application/json:
+          schema:
+            $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
+    "404":
+      description: The key was not found on the server, nothing to delete.
+      content:
+        application/json:
+          schema:
+            $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
+    "500":
+      $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"

--- a/apis/graffiti.yaml
+++ b/apis/graffiti.yaml
@@ -2,9 +2,7 @@ get:
   operationId: getGraffiti
   summary: Get Graffiti
   description: |
-    Get the graffiti for an individual validator. This graffiti is the one used by the
-    validator when proposing blocks. If no graffiti is set explicitly, returns
-    the process-wide default.
+    Get the graffiti for an individual validator.
   security:
     - bearerAuth: []
   tags:
@@ -48,8 +46,7 @@ post:
   operationId: setGraffiti
   summary: Set Graffiti
   description: |
-    Set the graffiti for an individual validator. This graffiti will be used instead
-    of the process-wide default by the validator when proposing blocks.
+    Set the graffiti for an individual validator.
   security:
     - bearerAuth: []
   tags:
@@ -88,8 +85,7 @@ delete:
   operationId: deleteGraffiti
   summary: Delete Configured Graffiti
   description: |
-    Delete the configured graffiti for the specified public key. The process-wide default
-    will be used by the validator when proposing blocks.
+    Delete the configured graffiti for the specified public key.
   security:
     - bearerAuth: []
   tags:

--- a/apis/graffiti.yaml
+++ b/apis/graffiti.yaml
@@ -21,7 +21,7 @@ get:
       content:
         application/json:
           schema:
-            title: ListGraffitiResponse
+            title: GraffitiResponse
             type: object
             required: [data]
             properties:

--- a/apis/graffiti.yaml
+++ b/apis/graffiti.yaml
@@ -48,7 +48,8 @@ post:
   operationId: setGraffiti
   summary: Set Graffiti
   description: |
-    Set the graffiti for an individual validator.
+    Set the graffiti for an individual validator. This graffiti will be used instead
+    of the process-wide default by the validator when proposing blocks.
   security:
     - bearerAuth: []
   tags:
@@ -87,7 +88,8 @@ delete:
   operationId: deleteGraffiti
   summary: Delete Configured Graffiti
   description: |
-    Delete the configured graffiti for the specified public key.
+    Delete the configured graffiti for the specified public key. The process-wide default
+    will be used by the validator when proposing blocks.
   security:
     - bearerAuth: []
   tags:

--- a/apis/graffiti.yaml
+++ b/apis/graffiti.yaml
@@ -2,7 +2,8 @@ get:
   operationId: getGraffiti
   summary: Get Graffiti
   description: |
-    Get the graffiti for an individual validator.
+    Get the graffiti for an individual validator. If no graffiti is set
+    explicitly, returns the process-wide default.
   security:
     - bearerAuth: []
   tags:
@@ -104,7 +105,7 @@ delete:
     "401":
       $ref: "../keymanager-oapi.yaml#/components/responses/Unauthorized"
     "403":
-      description: A graffiti was found, but cannot be removed. This may be because the graffit was in configuration files that cannot be updated.
+      description: A graffiti was found, but cannot be removed. This may be because the graffiti was in configuration files that cannot be updated.
       content:
         application/json:
           schema:

--- a/apis/graffiti.yaml
+++ b/apis/graffiti.yaml
@@ -3,8 +3,8 @@ get:
   summary: Get Graffiti
   description: |
     Get the graffiti for an individual validator. This graffiti is the one used by the
-    validator when proposing blocks. If no graffiti has been set explicitly for
-    a key then the process-wide default will be returned.
+    validator when proposing blocks. If no graffiti is set explicitly, returns
+    the process-wide default.
   security:
     - bearerAuth: []
   tags:
@@ -48,8 +48,7 @@ post:
   operationId: setGraffiti
   summary: Set Graffiti
   description: |
-    Set the graffiti for an individual validator. This graffiti will be used instead
-    of the process-wide default by the validator when proposing blocks.
+    Set the graffiti for an individual validator.
   security:
     - bearerAuth: []
   tags:

--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -35,6 +35,8 @@ tags:
     description: Set of endpoints for management of fee recipient.
   - name: Gas Limit
     description: Set of endpoints for management of gas limits.
+  - name: Graffiti
+    description: Set of endpoints for management of graffiti.
   - name: Local Key Manager
     description: Set of endpoints for key management of local keys.
   - name: Remote Key Manager
@@ -51,6 +53,8 @@ paths:
     $ref:  './apis/fee_recipient.yaml'
   /eth/v1/validator/{pubkey}/gas_limit:
     $ref:  './apis/gas_limit.yaml'
+  /eth/v1/validator/{pubkey}/graffiti:
+    $ref:  './apis/graffiti.yaml'
   /eth/v1/validator/{pubkey}/voluntary_exit:
     $ref: './apis/voluntary_exit.yaml'
 
@@ -72,6 +76,8 @@ components:
       $ref: './types/fee_recipient.yaml'
     GasLimit:
       $ref: './types/gas_limit.yaml'
+    Graffiti:
+      $ref: './types/graffiti.yaml'
     Uint64:
       $ref: './types/uint.yaml#/Uint64'
     SignerDefinition:

--- a/types/graffiti.yaml
+++ b/types/graffiti.yaml
@@ -1,0 +1,3 @@
+type: string
+description: "Arbitrary data validator wants to include in block."
+example: "plain text value"

--- a/types/graffiti.yaml
+++ b/types/graffiti.yaml
@@ -1,3 +1,3 @@
 type: string
-description: "Arbitrary data validator wants to include in block."
+description: "Arbitrary data to set in the graffiti field of BeaconBlockBody"
 example: "plain text value"


### PR DESCRIPTION
Add keymanager API to manage graffiti per validator.

The rationale for this is similar as for gas limit (https://github.com/ethereum/keymanager-APIs/pull/39), the graffiti is already part of proposer config file and it should be quite simple to implement (https://github.com/ChainSafe/lodestar/pull/6083).

