### PR TITLE
Use ERC-55 mixed-case checksum address encoding for execution address

### DIFF
--- a/types/eth_address.yaml
+++ b/types/eth_address.yaml
@@ -1,4 +1,4 @@
 type: string
 description: "An address on the execution (Ethereum 1) network."
-example: "0xabcf8e0d4e9587369b2301d0790347320302cc09"
+example: "0xAbcF8e0d4e9587369b2301D0790347320302cc09"
 pattern: "^0x[a-fA-F0-9]{40}$"


### PR DESCRIPTION
- Apply changes from https://github.com/ethereum/beacon-APIs/pull/396