### PR TITLE
Clarify authentication and token management

### DIFF
--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -13,8 +13,10 @@ info:
     and "Accept: application/json" headers.
 
     All sensitive routes are to be authenticated with a token. This token should be provided by the user via a secure channel:
-      - Log the token to stdout when running the binary with the key manager API enabled
-      - Read the token from a file available to the binary
+      - Log the token file path to stdout when running the binary with the key manager API enabled
+      - Read the token from a file available to the binary, the path to the token file should be configurable
+      - If the token file does not exist or is empty, generate a new token and write it to the file
+      - The token should remain the same across multiple restarts of the binary
   version: "v1.0.0"
   contact:
     name: Ethereum Github
@@ -63,7 +65,7 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: URL safe token, optionally JWT
+      bearerFormat: URL safe, opaque token
 
   schemas:
     Pubkey:

--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -12,11 +12,12 @@ info:
     All requests by default send and receive JSON, and as such should have either or both of the "Content-Type: application/json"
     and "Accept: application/json" headers.
 
-    All sensitive routes are to be authenticated with a token. This token should be provided by the user via a secure channel:
-      - Log the token file path to stdout when running the binary with the key manager API enabled
-      - Read the token from a file available to the binary, the path to the token file should be configurable
-      - If the token file does not exist or is empty, generate a new token and write it to the file
-      - The token should remain the same across multiple restarts of the binary
+    All sensitive routes MUST be authenticated with a token.
+
+    The keymanager binary SHOULD accept a configuration parameter: `token-file`, which designates a file containing the hex-encoded token
+    of at least 256 bits. If such a parameter is not given, the client SHOULD generate such a token and write it to a file, to be reused
+    across multiple restarts of the binary. If such a parameter is given, but the file or token cannot be read, the client SHOULD treat this
+    as an error: either abort the startup, or show the error and continue without exposing the keymanager routes.
   version: "v1.0.0"
   contact:
     name: Ethereum Github

--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -14,10 +14,10 @@ info:
 
     All sensitive routes MUST be authenticated with a token.
 
-    The keymanager binary SHOULD accept a configuration parameter: `token-file`, which designates a file containing the hex-encoded token
+    The key manager binary SHOULD accept a configuration parameter: `token-file`, which designates a file containing the hex-encoded token
     of at least 256 bits. If such a parameter is not given, the client SHOULD generate such a token and write it to a file, to be reused
     across multiple restarts of the binary. If such a parameter is given, but the file or token cannot be read, the client SHOULD treat this
-    as an error: either abort the startup, or show the error and continue without exposing the keymanager routes.
+    as an error: either abort the startup, or show the error and continue without exposing the key manager routes.
   version: "v1.0.0"
   contact:
     name: Ethereum Github


### PR DESCRIPTION
Based on the [discussion on discord](https://discord.com/channels/595666850260713488/710831784991916072/1215314186033430568), clarifies authentication (token format) and adds a few more notes on how the token should be managed by the binary (validator client / remote signer).

These are just the basic requirements a client should support, and ideally be backward compatible for all clients and not break existing tooling (e.g dappnode). The goal is to make it clearer for consumers on what to expect and improve client interoperability.

Additional protections can be implemented based on client specific requirements such as application layer HTTPS or a more secure approach to store the token on the file system.

Related 
- https://github.com/ethereum/keymanager-APIs/issues/9
- https://github.com/ethereum/pm/issues/973#issuecomment-1971391706