### PR TITLE
chore: :memo: update docs Prysm domain to prysm.offchainlabs.com

### DIFF
--- a/flows/client-specific/prysm/README.md
+++ b/flows/client-specific/prysm/README.md
@@ -6,7 +6,7 @@ There are some Prysm specific quirks that this document would like to make users
 ### Prysm Default Validator API Address
 `http://127.0.0.1:7500/`
 
-Prysm by default runs on the above address when running with `--web` flag. please look at our documentation [here](https://docs.prylabs.network/docs/prysm-usage/web-interface) for more information. Prysm includes its own native UI implementation as well.
+Prysm by default runs on the above address when running with `--web` flag. please look at our documentation [here](https://prysm.offchainlabs.com/docs/monitoring-alerts-metrics/web-interface/) for more information. Prysm includes its own native UI implementation as well.
 
 ## prysm version 2.0.7
 


### PR DESCRIPTION
Updated documentation URL from https://docs.prylabs.network/docs to https://prysm.offchainlabs.com/docs and new urls paths.