### PR TITLE
Return 404 for all endpoints if key not found

### DIFF
--- a/apis/fee_recipient.yaml
+++ b/apis/fee_recipient.yaml
@@ -111,10 +111,6 @@ delete:
           schema:
             $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
     "404":
-      description: The key was not found on the server, nothing to delete.
-      content:
-        application/json:
-          schema:
-            $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
+      $ref: "../keymanager-oapi.yaml#/components/responses/NotFound"
     "500":
       $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"

--- a/apis/gas_limit.yaml
+++ b/apis/gas_limit.yaml
@@ -117,10 +117,6 @@ delete:
           schema:
             $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
     "404":
-      description: The key was not found on the server, nothing to delete.
-      content:
-        application/json:
-          schema:
-            $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
+      $ref: "../keymanager-oapi.yaml#/components/responses/NotFound"
     "500":
       $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"

--- a/apis/graffiti.yaml
+++ b/apis/graffiti.yaml
@@ -112,10 +112,6 @@ delete:
           schema:
             $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
     "404":
-      description: The key was not found on the server, nothing to delete.
-      content:
-        application/json:
-          schema:
-            $ref: "../keymanager-oapi.yaml#/components/schemas/ErrorResponse"
+      $ref: "../keymanager-oapi.yaml#/components/responses/NotFound"
     "500":
       $ref: "../keymanager-oapi.yaml#/components/responses/InternalError"

--- a/keymanager-oapi.yaml
+++ b/keymanager-oapi.yaml
@@ -114,7 +114,7 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
     NotFound:
-      description: "Path not found"
+      description: "The key was not found on the server"
       content:
         application/json:
           schema:


### PR DESCRIPTION
This PR clarifies 404 response status code behavior and removes duplicated 404 response definitions.

All relevant endpoints now document 404 as a missing validator key on the server (instead of generic "Path not found" wording), matching the intended semantics.