### PR TITLE
proposing we don't support individual gas limits post gloas

### DIFF
--- a/apis/gas_limit.yaml
+++ b/apis/gas_limit.yaml
@@ -50,6 +50,8 @@ post:
     node for use on future block proposals. The beacon node is responsible for informing external
     block builders of the change.
 
+    NOTE: Post Gloas, individual validator updates update the global default instead.
+
     The server may return a 400 status code if no external builder is configured.
 
     WARNING: The gas_limit is not used on Phase0 or Altair networks.


### PR DESCRIPTION
adding the ability to configure gas limits on a per validator basis  on a validator client seems flawed telling the validator client to drastically shift between values potentially, I'm porposing post gloas we should just make the endpoint update the global default... 