### PR TITLE
Reference BuilderRequestAuth in auth_data description

### DIFF
--- a/types/builder_entry.yaml
+++ b/types/builder_entry.yaml
@@ -79,9 +79,9 @@ BuilderEntry:
       pattern: "^0x(?:[a-fA-F0-9]{2}){1,4096}$"
       description: |
         Opaque data used to authenticate this validator's requests to the builder. Agreed with the
-        builder out of band and placed verbatim in the `RequestAuth.data` the validator signs. The
-        builder checks the signature and the exact bytes. Its meaning is left to the two parties
-        (for example, a shared secret). At most `MAX_DATA_SIZE` (4096) bytes.
+        builder out of band and placed verbatim in the `BuilderRequestAuth.data` the validator
+        signs. The builder checks the signature and the exact bytes. Its meaning is left to the two
+        parties (for example, a shared secret). At most `MAX_BUILDER_AUTH_DATA_SIZE` (4096) bytes.
 
         The keymanager treats this value as opaque bytes: it only ever compares `auth_data` values
         for equality, and never parses or inspects them. When no value has been agreed with the

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -22,5 +22,5 @@ Vero
 Gwei
 uri
 UTF
-RequestAuth
+BuilderRequestAuth
 produceBlockV


### PR DESCRIPTION
aligns keymanager api with latest spec changes in https://github.com/ethereum/beacon-APIs/pull/630 and https://github.com/ethereum/builder-specs/pull/165